### PR TITLE
Arithmetics

### DIFF
--- a/startrak/imageutils.py
+++ b/startrak/imageutils.py
@@ -3,7 +3,7 @@ import numpy as np
 
 __all__ = ['sigma_stretch']
 
-def sigma_stretch(image : ImageLike, sigma=1.0) -> NDArray[np.uint8]:
+def sigma_stretch(image : ImageLike, sigma=1.0) -> NDArray:
 	'''
 		Sigma clipping linear stretch algorithm
 
@@ -18,7 +18,7 @@ def sigma_stretch(image : ImageLike, sigma=1.0) -> NDArray[np.uint8]:
 	image = np.clip((image - smin) * (255 / (smax - smin)), 0, 255)
 	return image.astype(np.uint8)
 
-def linear_stretch(image : ImageLike, smin : RealDType, smax: RealDType) -> NDArray[np.uint8]:
+def linear_stretch(image : ImageLike, smin : RealDType, smax: RealDType) -> NDArray:
 	'''
 		Linear clipping stretch algorithm
 

--- a/startrak/imageutils.py
+++ b/startrak/imageutils.py
@@ -18,7 +18,7 @@ def sigma_stretch(image : ImageLike, sigma=1.0) -> NDArray[np.uint8]:
 	image = np.clip((image - smin) * (255 / (smax - smin)), 0, 255)
 	return image.astype(np.uint8)
 
-def linear_stretch(image : ImageLike, smin : NumberLike, smax: NumberLike) -> NDArray[np.uint8]:
+def linear_stretch(image : ImageLike, smin : RealDType, smax: RealDType) -> NDArray[np.uint8]:
 	'''
 		Linear clipping stretch algorithm
 

--- a/startrak/native/__init__.py
+++ b/startrak/native/__init__.py
@@ -3,16 +3,18 @@ try:
 	__compiled__ = False
 	from .collections import position
 	from .collections import native_array
+	from . import numeric
 	from . import classes
-	from .collections import starlist
 	from . import abstract
+	from .collections import starlist
 except:
 	__compiled__ = True
 	from startrak.native.collections import position
 	from startrak.native.collections import native_array
+	from startrak.native import numeric
 	import startrak.native.classes as classes
-	from startrak.native.collections import starlist
 	import startrak.native.abstract as abstract
+	from startrak.native.collections import starlist
 
 
 Position = position.Position

--- a/startrak/native/__init__.py
+++ b/startrak/native/__init__.py
@@ -2,12 +2,14 @@
 try:
 	__compiled__ = False
 	from .collections import position
+	from .collections import native_array
 	from . import classes
 	from .collections import starlist
 	from . import abstract
 except:
 	__compiled__ = True
 	from startrak.native.collections import position
+	from startrak.native.collections import native_array
 	import startrak.native.classes as classes
 	from startrak.native.collections import starlist
 	import startrak.native.abstract as abstract
@@ -16,6 +18,7 @@ except:
 Position = position.Position
 PositionLike = position.PositionLike
 PositionArray = position.PositionArray
+Array = native_array.Array
 
 Star = classes.Star
 ReferenceStar = classes.ReferenceStar

--- a/startrak/native/abstract.py
+++ b/startrak/native/abstract.py
@@ -42,7 +42,7 @@ class StarDetector(ABC):
 		if len(positions) == 0:
 			print('No stars were detected, try adjusting the parameters')
 			return StarList()
-		return StarList([Star(self.star_name + str(i), positions[i], int(apertures[i])) 
+		return StarList( *[Star(self.star_name + str(i), positions[i], int(apertures[i])) 
 					for i in range(len(positions))])
 
 

--- a/startrak/native/alias.py
+++ b/startrak/native/alias.py
@@ -1,17 +1,25 @@
 # This file should only contain type aliases or generic type declarations.
 from __future__ import annotations
-
-from typing import Callable, List, TypeVar, Union
+from typing import Callable, Collection, List, Sequence, Tuple, TypeVar, Union
 import numpy as np
-from numpy.typing import NDArray
+from numpy.typing import NDArray as _NDArray
 
 ValueType = Union[int, float, str, bool]
-NumberLike = Union[np.uint, np.float_]
-ImageLike = NDArray[NumberLike]
+RealNumber = float | int
+RealDType = Union[np.uint, np.float_]
+
+_TReal = TypeVar('_TReal', bound= RealNumber)
+
+ImageLike = _NDArray[RealDType]
+NDArray = _NDArray[RealDType]
+
+
+_ArrayLike = Sequence[_TReal | Sequence[_TReal]] | NDArray
+ArrayLike =  _ArrayLike[RealNumber]
 
 _DecoratorReturn = TypeVar('_DecoratorReturn')
 Decorator = Callable[..., Callable[..., _DecoratorReturn]]
 
 _IndexLike = int | bool 
 _IndexLike_n =  np.int_ | np.bool_
-MaskLike = List[_IndexLike] | NDArray[_IndexLike_n]
+MaskLike = List[_IndexLike] | _NDArray[_IndexLike_n]

--- a/startrak/native/classes.py
+++ b/startrak/native/classes.py
@@ -1,6 +1,6 @@
 # compiled module
 from __future__ import annotations
-from mypy_extensions import mypyc_attr, i16, u8
+from mypy_extensions import mypyc_attr
 from dataclasses import dataclass
 from functools import lru_cache
 import math
@@ -247,7 +247,7 @@ class TrackingSolution(STObject):
 	_r : float							# rotation angle in radians
 	
 	def __init__(self, a : float, b : float,  c : float, d : float, e : 
-									float, r : Optional[float] = None,  l : Optional[List[u8]] = None):
+					float, r : Optional[float] = None,  l : Optional[List[int]] = None):
 		self._a = a
 		self._b = b
 		self._c = c
@@ -259,14 +259,15 @@ class TrackingSolution(STObject):
 			self._r = r
 		else:
 			self._r = math.atan2(a, b)
-
-	def new(self, *,delta_pos : PositionArray,
-								delta_angle : NDArray[np.float_],
-								image_size : Tuple[int, ...],
-								weights : Tuple[float, ...] | None = None,
-								lost_indices : List[u8] = [],
-								rejection_sigma : int = 3,
-								rejection_iter : u8 = 1) -> TrackingSolution:
+	
+	@classmethod
+	def new(cls, *,delta_pos : PositionArray,
+						delta_angle : NDArray[np.float_],
+						image_size : Tuple[int, ...],
+						weights : Tuple[float, ...] | None = None,
+						lost_indices : List[int] = [],
+						rejection_sigma : int = 3,
+						rejection_iter : int = 1) -> Self:
 
 		mask = list(range(len(delta_pos)))
 		pos_residuals = delta_pos - np.nanmean(delta_pos, axis= 0)
@@ -278,7 +279,7 @@ class TrackingSolution(STObject):
 			pos_std : float =  np.nanmean(np.power(pos_residuals[mask], 2))
 			ang_std : float =  np.nanmean(np.power(ang_residuals[mask], 2))
 			rej_count, rej_error = 0, 0.0
-			exx: float; eyy: float; eaa : float; i: u8
+			exx: float; eyy: float; eaa : float; i: int
 			# Translation error
 			for i, (exx, eyy) in enumerate(pos_residuals):
 				isnan = math.isnan(exx + eyy)
@@ -332,7 +333,7 @@ class TrackingSolution(STObject):
 		c = dx + j - j * a + k * b
 		d = dy + k - k * a - j * b
 
-		return TrackingSolution(a, b, c, d, e, r, l)
+		return cls(a, b, c, d, e, r, l)
 
 	@property
 	def matrix(self) -> NDArray[np.float_]:

--- a/startrak/native/collections/native_array.py
+++ b/startrak/native/collections/native_array.py
@@ -1,0 +1,36 @@
+# compiled module
+from __future__ import annotations
+import numpy as np
+from startrak.native.ext import STCollection
+from numpy.typing import NDArray
+
+class Array(STCollection[float]):
+	def __add__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array([ a + b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a + other for a in self._internal] )
+	
+	def __radd__(self, other: Array | float | int) -> Array:
+		return self.__add__(other)
+	
+	def __sub__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array([ a - b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a - other for a in self._internal] )
+	
+	def __mul__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array([ a * b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a * other for a in self._internal] )
+	
+	def __truediv__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array( [ a / b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a / other for a in self._internal] )
+	
+	def __array__(self, dtype=None) -> NDArray[np.float_]:
+		return np.array(self._internal)

--- a/startrak/native/collections/native_array.py
+++ b/startrak/native/collections/native_array.py
@@ -7,30 +7,30 @@ from numpy.typing import NDArray
 class Array(STCollection[float]):
 	def __add__(self, other: Array | float | int) -> Array:
 		if isinstance(other, Array):
-			return Array([ a + b for a,b in zip(self._internal, other._internal)])
+			return Array( *[ a + b for a,b in zip(self._internal, other._internal)])
 		else:
-			return Array( [a + other for a in self._internal] )
+			return Array( *[a + other for a in self._internal] )
 	
 	def __radd__(self, other: Array | float | int) -> Array:
 		return self.__add__(other)
 	
 	def __sub__(self, other: Array | float | int) -> Array:
 		if isinstance(other, Array):
-			return Array([ a - b for a,b in zip(self._internal, other._internal)])
+			return Array( *[ a - b for a,b in zip(self._internal, other._internal)])
 		else:
-			return Array( [a - other for a in self._internal] )
+			return Array( *[a - other for a in self._internal] )
 	
 	def __mul__(self, other: Array | float | int) -> Array:
 		if isinstance(other, Array):
-			return Array([ a * b for a,b in zip(self._internal, other._internal)])
+			return Array( *[ a * b for a,b in zip(self._internal, other._internal)])
 		else:
-			return Array( [a * other for a in self._internal] )
+			return Array( *[a * other for a in self._internal] )
 	
 	def __truediv__(self, other: Array | float | int) -> Array:
 		if isinstance(other, Array):
-			return Array( [ a / b for a,b in zip(self._internal, other._internal)])
+			return Array( *[ a / b for a,b in zip(self._internal, other._internal)])
 		else:
-			return Array( [a / other for a in self._internal] )
+			return Array( *[a / other for a in self._internal] )
 	
 	def __array__(self, dtype=None) -> NDArray[np.float_]:
 		return np.array(self._internal)

--- a/startrak/native/collections/position.py
+++ b/startrak/native/collections/position.py
@@ -105,14 +105,12 @@ class PositionArray(STCollection[Position]):
 	_cached_y : List[float] | None
 	_cached_x : List[float] | None
 
-	def __init__(self, positions: Iterable[Position] | Iterable[PositionLike] | None = None):
+	def __init__(self, *positions: Position | PositionLike):
 		self._closed = False
 		self._cached_y = None
 		self._cached_x = None
-		if positions is None:
-			self._internal = list[Position]()
-		else:
-			self._internal = [Position.new(pos) for pos in positions]
+		
+		self._internal = [Position.new(pos) for pos in positions]
 	@property
 	def is_closed(self) -> bool:
 		return super().is_closed
@@ -167,17 +165,17 @@ class PositionArray(STCollection[Position]):
 
 	def __add__(self, other : PositionArray | Position | PositionLike):
 		if type(other) is PositionArray:
-			return PositionArray([ a + b for a,b in zip(self._internal, other._internal)])
+			return PositionArray( *[a + b for a,b in zip(self._internal, other._internal)] )
 		elif isinstance(other, Position) or isinstance(other, tuple|list|np.ndarray):
-			return PositionArray( [a + other for a in self._internal] )
+			return PositionArray( *[a + other for a in self._internal] )
 		else:
 			raise ValueError(type(other))
 	
 	def __sub__(self, other : PositionArray | Position | PositionLike):
 		if type(other) is PositionArray:
-			return PositionArray([ a - b for a,b in zip(self._internal, other._internal)])
+			return PositionArray( *[ a - b for a,b in zip(self._internal, other._internal)])
 		elif isinstance(other, Position) or isinstance(other, tuple|list|np.ndarray):
-			return PositionArray( [a - other for a in self._internal] )
+			return PositionArray( *[a - other for a in self._internal] )
 		else:
 			raise ValueError(type(other))
 

--- a/startrak/native/collections/position.py
+++ b/startrak/native/collections/position.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 import numpy as np
 from numpy.typing import NDArray
-from typing import Any, Iterable, List, Literal, NamedTuple, Tuple, Union, overload
-
+from typing import Any, Iterable, List, Literal, NamedTuple, Sequence, Tuple, Union, overload
 from startrak.native.alias import MaskLike
 from startrak.native.ext import STCollection
 
@@ -12,7 +11,6 @@ PositionLike = Union[Tuple[float|Any, ...], Tuple[float|Any, float|Any], List[fl
 _MatrixLike3x3 = NDArray[np.floating] | List[List | Tuple | NDArray] | Tuple[List | Tuple | NDArray, ...]
 _LiteralAxis = Literal['x', 0, 'y', 1]
 
-	
 
 class Position(NamedTuple):
 	x : float
@@ -60,13 +58,35 @@ class Position(NamedTuple):
 		result[1] = matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2]
 		return Position(*result)
 	
-	def __add__(self, other : Position | PositionLike,/) -> Position:
-		if len(other) != 2: raise ValueError(other)
+	def __add__(self, other : Position | PositionLike | Any,/) -> Position:
+		if other == 0:
+			return self
+		assert isinstance(other, Sequence), 'Not a sequence'
+		assert len(other) == 2, 'Cannot coherce 2D Position with Sequence of length different than 2'
 		return Position(self[0] + other[0], self[1] + other[1])
 	
-	def __sub__(self, other : Position | PositionLike, /) -> Position:
-		if len(other) != 2: raise ValueError(other)
+	def __sub__(self, other : Position | PositionLike | Any, /) -> Position:
+		assert isinstance(other, Sequence), 'Not a sequence'
+		assert len(other) == 2, 'Cannot coherce 2D Position with Sequence of length different than 2'
 		return Position(self.x - other[0], self.y - other[1])
+	
+	def __radd__(self, other : Position | PositionLike | Any,/) -> Position:
+		return self.__add__(other)
+	
+	def __mul__(self, other : Position | PositionLike | Any, /) -> Position:
+		if isinstance(other, float | int):
+			return Position(self.x * other, self.y * other)
+		assert isinstance(other, Sequence), 'Not a sequence'
+		assert len(other) == 2, 'Cannot coherce 2D Position with Sequence of length different than 2'
+		return Position(self.x * other[0], self.y * other[1])
+	
+	def __truediv__(self, other : Position | PositionLike | Any, /) -> Position:
+		if isinstance(other, float | int):
+			return Position(self.x / other, self.y / other)
+		assert isinstance(other, Sequence), 'Not a sequence'
+		assert len(other) == 2, 'Cannot coherce 2D Position with Sequence of length different than 2'
+		return Position(self.x / other[0], self.y / other[1])
+
 	
 	def __array__(self, dtype=None) -> NDArray[np.float_]:
 		return np.array(self[:])

--- a/startrak/native/collections/starlist.py
+++ b/startrak/native/collections/starlist.py
@@ -15,7 +15,7 @@ class StarList(STCollection[Star]):
 	
 	@property
 	def positions(self) -> PositionArray:
-		return PositionArray((s.position for s in self._internal))
+		return PositionArray( *(s.position for s in self._internal))
 	
 	def to_dict(self) -> Dict[str, Star]:
 		return {s.name : s for s in self._internal}

--- a/startrak/native/fits.py
+++ b/startrak/native/fits.py
@@ -1,6 +1,6 @@
 from mmap import ACCESS_READ, ALLOCATIONGRANULARITY, mmap
 from typing import Any, Final, Iterator, TypeVar, Tuple, overload
-from startrak.native.alias import ValueType, NumberLike
+from startrak.native.alias import ValueType, RealDType
 from numpy.typing import NDArray
 import numpy as np
 _BitDepth =  TypeVar('_BitDepth', bound= np.dtype)
@@ -64,7 +64,7 @@ def _validate_byteline(line : bytes):
 		raise IOError('Invalid header syntax', line)
 	return True
 
-def _bitsize(depth : int) -> np.dtype[NumberLike]:
+def _bitsize(depth : int) -> np.dtype[RealDType]:
 	if depth == 8: return np.dtype(np.uint8)
 	elif depth == 16: return np.dtype(np.uint16)
 	elif depth == 32: return np.dtype(np.uint32)

--- a/startrak/native/numeric.py
+++ b/startrak/native/numeric.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 import math
 from typing import Collection, overload
-from startrak.native import Array, Position
+from startrak.native.collections.position import Position
 
 @overload
-def average(values : Collection[float] | Array, weights : Collection[float] | None) -> float: ...
+def average(values : Collection[float], weights : Collection[float] | None = None) -> float: ...
 @overload
-def average(values : Collection[Position], weights : Collection[float] | None) -> Position: ...
-def average(values : Collection[float | Position] | Array, weights : Collection[float] | None = None) -> float | Position:
+def average(values : Collection[Position], weights : Collection[float] | None = None) -> Position: ...
+def average(values : Collection[float | Position], weights : Collection[float] | None = None) -> float | Position:
 	if weights is not None and (s := sum(weights)) != 0:
 		assert len(values) == len(weights)
 		return sum([n * w for n, w in zip(values, weights)]) / s
@@ -16,7 +16,7 @@ def average(values : Collection[float | Position] | Array, weights : Collection[
 		return sum(values) / len(values)
 
 
-def variance(values : Collection[float] | Array, weights : Collection[float] | None = None) -> float:
+def variance(values : Collection[float], weights : Collection[float] | None = None) -> float:
 	avg = average(values, weights)
 	if weights is not None and (s := sum(weights)) != 0:
 		assert len(values) == len(weights)
@@ -24,5 +24,5 @@ def variance(values : Collection[float] | Array, weights : Collection[float] | N
 	else:
 		return sum((n -  avg) * (n -  avg) for n in values) / len(values)
 
-def stdev(values : Collection[float] | Array, weights : Collection[float] | None = None) -> float:
+def stdev(values : Collection[float], weights : Collection[float] | None = None) -> float:
 	return math.sqrt(variance(values, weights))

--- a/startrak/native/numeric.py
+++ b/startrak/native/numeric.py
@@ -2,44 +2,8 @@
 from __future__ import annotations
 import math
 from typing import Collection, overload
+from startrak.native import Array, Position
 
-import numpy as np
-from startrak.native import Position
-from startrak.native.ext import STCollection
-from numpy.typing import NDArray
-
-
-class Array(STCollection[float]):
-	def __add__(self, other: Array | float | int) -> Array:
-		if isinstance(other, Array):
-			return Array([ a + b for a,b in zip(self._internal, other._internal)])
-		else:
-			return Array( [a + other for a in self._internal] )
-	
-	def __radd__(self, other: Array | float | int) -> Array:
-		return self.__add__(other)
-	
-	def __sub__(self, other: Array | float | int) -> Array:
-		if isinstance(other, Array):
-			return Array([ a - b for a,b in zip(self._internal, other._internal)])
-		else:
-			return Array( [a - other for a in self._internal] )
-	
-	def __mul__(self, other: Array | float | int) -> Array:
-		if isinstance(other, Array):
-			return Array([ a * b for a,b in zip(self._internal, other._internal)])
-		else:
-			return Array( [a * other for a in self._internal] )
-	
-	def __truediv__(self, other: Array | float | int) -> Array:
-		if isinstance(other, Array):
-			return Array( [ a / b for a,b in zip(self._internal, other._internal)])
-		else:
-			return Array( [a / other for a in self._internal] )
-	
-	def __array__(self, dtype=None) -> NDArray[np.float_]:
-		return np.array(self._internal)
-		
 @overload
 def average(values : Collection[float] | Array, weights : Collection[float] | None) -> float: ...
 @overload

--- a/startrak/native/numeric.py
+++ b/startrak/native/numeric.py
@@ -1,0 +1,65 @@
+# compiled module
+from __future__ import annotations
+import math
+from typing import Collection, Iterable, List, Literal, Self, Sized, Tuple, TypeVar, cast, overload
+
+import numpy as np
+from startrak.native import Position
+from startrak.native.alias import MaskLike
+from startrak.native.ext import STCollection
+from numpy.typing import NDArray, ArrayLike
+
+
+class Array(STCollection[float]):
+	def __add__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array([ a + b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a + other for a in self._internal] )
+	
+	def __radd__(self, other: Array | float | int) -> Array:
+		return self.__add__(other)
+	
+	def __sub__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array([ a - b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a - other for a in self._internal] )
+	
+	def __mul__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array([ a * b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a * other for a in self._internal] )
+	
+	def __truediv__(self, other: Array | float | int) -> Array:
+		if isinstance(other, Array):
+			return Array( [ a / b for a,b in zip(self._internal, other._internal)])
+		else:
+			return Array( [a / other for a in self._internal] )
+	
+	def __array__(self, dtype=None) -> NDArray[np.float_]:
+		return np.array(self._internal)
+		
+@overload
+def average(values : Collection[float] | Array, weights : Collection[float] | None) -> float: ...
+@overload
+def average(values : Collection[Position], weights : Collection[float] | None) -> Position: ...
+def average(values : Collection[float | Position] | Array, weights : Collection[float] | None = None) -> float | Position:
+	if weights is not None and (s := sum(weights)) != 0:
+		assert len(values) == len(weights)
+		return sum([n * w for n, w in zip(values, weights)]) / s
+	else:
+		return sum(values) / len(values)
+
+
+def variance(values : Collection[float] | Array, weights : Collection[float] | None = None) -> float:
+	avg = average(values, weights)
+	if weights is not None and (s := sum(weights)) != 0:
+		assert len(values) == len(weights)
+		return sum([ w * (n - avg) ** 2 for n, w in zip(values, weights)]) / s
+	else:
+		return sum((n -  avg) * (n -  avg) for n in values) / len(values)
+
+def stdev(values : Collection[float] | Array, weights : Collection[float] | None = None) -> float:
+	return math.sqrt(variance(values, weights))

--- a/startrak/native/numeric.py
+++ b/startrak/native/numeric.py
@@ -1,13 +1,12 @@
 # compiled module
 from __future__ import annotations
 import math
-from typing import Collection, Iterable, List, Literal, Self, Sized, Tuple, TypeVar, cast, overload
+from typing import Collection, overload
 
 import numpy as np
 from startrak.native import Position
-from startrak.native.alias import MaskLike
 from startrak.native.ext import STCollection
-from numpy.typing import NDArray, ArrayLike
+from numpy.typing import NDArray
 
 
 class Array(STCollection[float]):

--- a/startrak/types/detection.py
+++ b/startrak/types/detection.py
@@ -44,7 +44,7 @@ class HoughCircles(StarDetector):
 
 		circles = cv2.HoughCircles(img, cv2.HOUGH_GRADIENT, 1,
 										minDist= self._min_dst, param1= self._p1, param2= self._p2, minRadius= self._min_size, maxRadius= self._max_size)
-		return PositionArray(circles[0][:, :2]), circles[0][:, 2].tolist()
+		return PositionArray(*circles[0][:, :2]), circles[0][:, 2].tolist()
 	
 class AdaptiveHoughCircles(HoughCircles):
 	_block_size : int
@@ -65,7 +65,7 @@ class AdaptiveHoughCircles(HoughCircles):
 											255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, blockSize= self._block_size, C= self._threshold)
 		circles = cv2.HoughCircles(img, cv2.HOUGH_GRADIENT, 1,
 										minDist= self._min_dst, param1= self._p1, param2= self._p2, minRadius= self._min_size, maxRadius= self._max_size)
-		return PositionArray(circles[0][:, :2]), circles[0][:, 2].tolist()
+		return PositionArray(*circles[0][:, :2]), circles[0][:, 2].tolist()
 
 class ThresholdHoughCircles(HoughCircles):
 	_threshold : int
@@ -82,5 +82,5 @@ class ThresholdHoughCircles(HoughCircles):
 		_, img = cv2.threshold(img, self._threshold, 255, cv2.THRESH_BINARY+cv2.THRESH_OTSU)
 		circles = cv2.HoughCircles(img, cv2.HOUGH_GRADIENT, 1,
 										minDist= self._min_dst, param1= self._p1, param2= self._p2, minRadius= self._min_size, maxRadius= self._max_size)
-		return PositionArray(circles[0][:, :2]), circles[0][:, 2].tolist()
+		return PositionArray(*circles[0][:, :2]), circles[0][:, 2].tolist()
 	

--- a/startrak/types/trackers.py
+++ b/startrak/types/trackers.py
@@ -68,9 +68,9 @@ class SimpleTracker(Tracker):
 
 				indices = np.transpose(np.nonzero(mask))
 				if len(indices) == 0: raise IndexError()
-				_w = np.clip(crop[indices[:, 0], indices[:, 1]] - bkg, 0, phot.flux) / phot.flux
+				_w = np.clip(crop[indices[:, 0], indices[:, 1]] - bkg, 0, phot.flux_max) / phot.flux
 				_w[np.isnan(_w)] = 0
-				average = np.average(indices, weights= _w, axis= 0)[::-1]
+				average = np.average(indices, weights= _w ** 2, axis= 0)[::-1]
 				# variance = np.average((indices - average[::-1])**2 , weights=_w, axis= 0)
 			except:
 				lost.append(i)

--- a/startrak/types/trackers.py
+++ b/startrak/types/trackers.py
@@ -90,13 +90,13 @@ class SimpleTracker(Tracker):
 		cross = np.cross(c_previous, c_current)
 		da = np.arctan2(cross,  dot)
 
-		return TrackingSolution(delta_pos= delta_pos, 
-										delta_angle= da, 
-										image_size= _image.shape, 
-										lost_indices= lost,
-										weights= self._model_weights,
-										rejection_sigma= self._r_sigma,
-										rejection_iter= self._r_iter)
+		return TrackingSolution.new(delta_pos= delta_pos, 
+											delta_angle= da, 
+											image_size= _image.shape, 
+											lost_indices= lost,
+											weights= self._model_weights,
+											rejection_sigma= self._r_sigma,
+											rejection_iter= self._r_iter)
 
 # todo: move elsewhere
 _Method = Literal['hough', 'hough_adaptive', 'hough_threshold']
@@ -206,9 +206,9 @@ class GlobalAlignmentTracker(Tracker):
 			weight_array = None
 
 		print(f'Matched {len(matched)} of {len(triangles)} triangles')
-		return TrackingSolution(delta_pos= delta_pos,
-										delta_angle= delta_rot,
-										image_size= image.shape,
-										weights= weight_array,
-										rejection_iter= self.iterations,
-										rejection_sigma= self.sigma)
+		return TrackingSolution.new(delta_pos= delta_pos,
+											delta_angle= delta_rot,
+											image_size= image.shape,
+											weights= weight_array,
+											rejection_iter= self.iterations,
+											rejection_sigma= self.sigma)


### PR DESCRIPTION
This pull request includes various improvements, for which the most important ones are:

* Array class

> This class is meant to be used inside mypyc compiled modules to facilitate type hinting while implementing mask indexing like numpy arrays.
> Unlike numpy arrays, the return type of the getter of this class returns a float object and not a np.floating_ object whcih cannot be interpreted with mypy.
> In general, this class should be used over numpy arrays in the following scenarios.
> * Inside a mypyc compiled module to have a predictable return type that can be further optimized.
> * Inside a mypyc module when masking is necesary.
> * When dealing with less than 100 entries.
> Startrak Arrays can perform slightly better than numpy with less than 100 entries.

* Arithmetic operations
> These operations include average (mean), variance and standard deviation. They are made to be used with Startrak Arrays and PositionArrays although Lists and Tuples are also supported.
> They live inside the native.numerics submodule

* Minor issues
> This includes small patches and fixes to other classes and modules while implementing the new methods above